### PR TITLE
feat(forest-ux): dashboard & teaser overhaul, per-tree 10/30, contras…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Validating from "./pages/Validating";
 import ValidatedSuccess from "./pages/ValidatedSuccess";
 import TransactionDetail from "./pages/TransactionDetail";
 import Dashboard from "./pages/Dashboard";
+import LoginPage from "./pages/Loginpage";
 
 export default function App() {
   const [params] = useSearchParams();
@@ -14,6 +15,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<Welcome />} />
       <Route path="/signup" element={<SignUp />} />
+      <Route path="/login" element={<LoginPage />} />
       <Route path="/validating" element={<Validating />} />
       <Route path="/validated" element={<ValidatedSuccess />} />
       <Route path="/transaction" element={<TransactionDetail />} />

--- a/src/components/TreeGarden.jsx
+++ b/src/components/TreeGarden.jsx
@@ -8,7 +8,7 @@ const STAGES = [stage1, stage2, stage3];
 
 export default function TreeGarden({
   uses = 0,            // 개인 또는 커뮤니티 사용 횟수
-  perTree = 100,       // 몇 회당 1그루인지
+  perTree = 30,       // 몇 회당 1그루인지
   label = "숲",
   maxColumns = 6,      // 그리드 열 개수
 }) {

--- a/src/components/TreeTeaser.css
+++ b/src/components/TreeTeaser.css
@@ -42,10 +42,18 @@
   display: grid;
   place-items: center;
   overflow: hidden;
+  position: relative;
 }
 .forest-cell img {
   width: 52px;
   height: auto;
+}
+.forest-cell.more {
+  font-weight: 900;
+  color: #1b5e20;
+  background: #ECF7EF;
+  border: 1px dashed #CDE9D4;
+  font-size: 14px;
 }
 
 /* 진행 바 */
@@ -59,7 +67,7 @@
 }
 .forest-progress-fill {
   height: 100%;
-  background: #4CAF50;
+  background: linear-gradient(90deg, #4CAF50, #2E7D32);
   transition: width .35s ease;
 }
 

--- a/src/components/TreeTeaser.jsx
+++ b/src/components/TreeTeaser.jsx
@@ -7,86 +7,115 @@ import stage1 from "../assets/trees/tree-1.png"; // 새싹
 import stage2 from "../assets/trees/tree-2.png"; // 중간
 import stage3 from "../assets/trees/tree-3.png"; // 완성
 
-function getGlobal() {
-  try {
-    const raw = localStorage.getItem("global_stats");
-    return raw ? JSON.parse(raw) : { totalUses: 0, totalPoints: 0 };
-  } catch {
-    return { totalUses: 0, totalPoints: 0 };
-  }
+/* -------- storage helpers -------- */
+function safeParse(json, fallback) {
+  try { return JSON.parse(json); } catch { return fallback; }
+}
+function readGlobal() {
+  const raw = localStorage.getItem("global_stats");
+  const obj = safeParse(raw, { totalUses: 0, totalPoints: 0 });
+  return {
+    totalUses: Number(obj.totalUses || 0),
+    totalPoints: Number(obj.totalPoints || 0),
+  };
 }
 
-export default function TreeTeaser({ perTree = 100, maxTiles = 6 }) {
-  const [globalStats, setGlobalStats] = useState({ totalUses: 0, totalPoints: 0 });
+/**
+ * TreeTeaser
+ * - 커뮤니티 기준: perTree=30회 => 1그루
+ * - maxTiles: 썸네일 격자에 보여줄 최대 그루 수 (나머지는 +N으로 요약)
+ */
+export default function TreeTeaser({ perTree = 30, maxTiles = 12 }) {
+  const [stats, setStats] = useState(() => readGlobal());
 
+  // 실시간 동기화: storage(다른 탭), 폴링(같은 탭), visibilitychange
   useEffect(() => {
-    setGlobalStats(getGlobal());
-
-    const handleStorageChange = () => {
-      setGlobalStats(getGlobal());
+    const onStorage = (e) => {
+      if (e.key === "global_stats") setStats(readGlobal());
     };
+    const onVisibility = () => {
+      if (!document.hidden) setStats(readGlobal());
+    };
+    const poll = setInterval(() => setStats(readGlobal()), 1500);
 
-    window.addEventListener('storage', handleStorageChange);
-
+    window.addEventListener("storage", onStorage);
+    document.addEventListener("visibilitychange", onVisibility);
     return () => {
-      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener("storage", onStorage);
+      document.removeEventListener("visibilitychange", onVisibility);
+      clearInterval(poll);
     };
   }, []);
 
-  const totalUses = Number(globalStats.totalUses || 0);
+  const totalUses = stats.totalUses;
 
+  // 그루/진행도 계산
   const trees = Math.floor(totalUses / perTree);
-  const progress = totalUses % perTree;
-  const pct = Math.min(100, Math.round((progress / perTree) * 100));
-  const leftToNext = perTree - progress === perTree ? 0 : perTree - progress;
+  const progress = totalUses % perTree;               // 다음 그루까지 남은 회수 계산의 기준
+  const leftToNext = progress === 0 ? 0 : perTree - progress;
+  const pct = Math.round((progress / perTree) * 100);
 
-  const tiles = useMemo(() => {
-    const numTrees = Math.floor(totalUses / perTree);
-    const progress = totalUses % perTree;
-    
-    const completedTrees = Math.min(maxTiles - 1, numTrees);
-    const showGrowingTree = numTrees < maxTiles || progress > 0;
-    
-    const tileArray = Array(completedTrees).fill(stage3);
-    
-    if (showGrowingTree) {
-        const stage = progress >= perTree * 0.67 ? stage3 : progress >= perTree * 0.34 ? stage2 : stage1;
-        tileArray.push(stage);
+  // 격자에 표시할 타일: 완성 그루 + 성장중 1개
+  const { tiles, overflowCount } = useMemo(() => {
+    const fullCount = Math.min(trees, Math.max(0, maxTiles)); // 완성 그루 타일
+    const remainTiles = Math.max(0, maxTiles - fullCount);
+
+    // 성장중 타일을 표시할지 결정: progress > 0 이고, 보여줄 칸이 남았을 때
+    const showGrowing = progress > 0 && remainTiles > 0;
+
+    // 완성 타일들
+    const arr = Array(fullCount).fill(stage3);
+
+    if (showGrowing) {
+      const stage =
+        progress >= perTree * 0.67 ? stage3 :
+        progress >= perTree * 0.34 ? stage2 : stage1;
+      arr.push(stage);
     }
 
-    return tileArray;
-  }, [totalUses, perTree, maxTiles]);
+    const totalShown = arr.length;
+    const totalTreesToRepresent = trees + (progress > 0 ? 1 : 0);
+    const overflow = Math.max(0, totalTreesToRepresent - totalShown);
+
+    return { tiles: arr, overflowCount: overflow };
+  }, [trees, progress, perTree, maxTiles]);
 
   return (
     <section className="forest-teaser" aria-labelledby="forest-teaser-title">
       <div className="forest-head">
         <div className="forest-eyebrow">우리 모두의 숲</div>
-        <h3 id="forest-teaser-title">
+        <h3 id="forest-teaser-title" className="forest-title">
           함께 키운 나무{" "}
           <b className="forest-strong" aria-live="polite" aria-atomic="true">
             {trees.toLocaleString()}
-          </b>그루
+          </b>
+          그루
         </h3>
         <p className="forest-sub">
           다음 나무까지 <b className="forest-strong">{leftToNext}</b>회
         </p>
       </div>
 
-      <div className="forest-grid" aria-hidden="true">
+      <div className="forest-grid">
         {tiles.map((src, i) => (
-          <div key={i} className="forest-cell">
+          <div key={i} className="forest-cell" aria-hidden="true">
             <img src={src} alt="" />
           </div>
         ))}
+        {overflowCount > 0 && (
+          <div className="forest-cell more" aria-label={`추가 나무 ${overflowCount}그루`}>
+            +{overflowCount.toLocaleString()}
+          </div>
+        )}
       </div>
 
       <div
         className="forest-progress"
         role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={pct}
         aria-label="다음 나무까지 진행률"
+        aria-valuemin={0}
+        aria-valuemax={perTree}
+        aria-valuenow={progress}
       >
         <div className="forest-progress-fill" style={{ width: `${pct}%` }} />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,44 @@
 @import url("./styles/tokens.css");
 @import url("./styles/util.css");
 
+/* ===== Webfonts ===== */
+/* Pretendard Variable (공식 CDN) */
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.9/variable/PretendardVariable-VF.css");
+
+/* Gmarket Sans (Light/Medium/Bold) - Noonnu CDN */
+@font-face {
+  font-family: 'GmarketSans';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansLight.woff') format('woff');
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'GmarketSans';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'GmarketSans';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansBold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ===== Font Tokens ===== */
+:root {
+  --font-body: 'Pretendard Variable', ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+
+  --font-heading: 'GmarketSans', 'Pretendard Variable', ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+}
+
 /* ===== Global Reset / Base ===== */
 *,
 *::before,
@@ -16,9 +54,7 @@ html {
 
 body {
   margin: 0;
-  font-family: 'Pretendard Variable', ui-sans-serif, system-ui, -apple-system,
-    "Segoe UI", Roboto, "Helvetica Neue", Arial,
-    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+  font-family: var(--font-body); /* 본문 = Pretendard Variable */
   color: var(--color-text);
   background: var(--color-bg);
   line-height: 1.6;
@@ -26,14 +62,30 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Heading: 제목/소제목은 Gmarket Sans */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  line-height: 1.3;
+  margin: 0 0 0.5em;
+}
+
+/* 기본 크기/굵기 스케일(필요시 조정) */
+h1 { font-size: 2rem;   font-weight: 700; } /* Bold */
+h2 { font-size: 1.5rem; font-weight: 500; } /* Medium */
+h3 { font-size: 1.25rem; font-weight: 500; }
+h4 { font-size: 1.125rem; font-weight: 500; }
+h5 { font-size: 1rem;   font-weight: 500; }
+h6 { font-size: .875rem; font-weight: 500; }
+
+/* 본문 계열은 Pretendard 유지 */
+p, li, small, span { font-family: var(--font-body); }
+
 /* 미디어/인라인 요소 기본 */
 img, svg, video { display: block; max-width: 100%; height: auto; }
 a { color: inherit; text-decoration: none; }
 
 /* 폼 요소: 폰트 상속 + 기본 외형 제거(컴포넌트 CSS가 스타일링) */
-button, input, select, textarea {
-  font: inherit;
-}
+button, input, select, textarea { font: inherit; }
 button {
   appearance: none;
   -webkit-appearance: none;
@@ -62,3 +114,7 @@ button {
     scroll-behavior: auto !important;
   }
 }
+
+/* ===== Utilities (선택) ===== */
+.font-gmarket { font-family: var(--font-heading); }     /* 수동으로 Gmarket 적용 */
+.font-pretendard { font-family: var(--font-body); }     /* 수동으로 Pretendard 적용 */

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -1,15 +1,21 @@
-/* 전역 변수 설정 */
+/* 전역 변수 */
 :root {
   --color-brand: #4caf50;
   --color-brand-strong: #2e7d32;
   --color-sub: #757575;
   --color-text: #333;
+
   --color-bg-personal: #F8FFF9;
   --color-border-personal: #E6F8EC;
-  --color-bg-global: #F6FBFF;
-  --color-border-global: #E6F0F8;
+
+  --color-bg-global: #0e2a1c;        /* 짙은 숲 배경 */
+  --color-border-global: #123a27;
+
   --radius-md: 16px;
-  --shadow-base: 0 8px 24px rgba(0,0,0,0.06);
+  --radius-sm: 12px;
+
+  --shadow-base: 0 10px 28px rgba(0,0,0,0.10);
+  --shadow-soft: 0 6px 18px rgba(0,0,0,0.06);
 }
 
 .dashboard-main {
@@ -31,65 +37,17 @@
   justify-content: space-between;
   align-items: center;
   flex-direction: column;
+  text-align: center;
 }
-
 .section-title {
   font-size: 20px;
   font-weight: 900;
   margin: 0;
 }
-
 .section-subtitle {
   font-size: 14px;
   color: var(--color-sub);
   margin-top: 8px;
-}
-
-/* 통계 카드 그리드 */
-.stats-grid {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: 24px;
-}
-
-.stat-card {
-  border-radius: 12px;
-  padding: 16px;
-}
-
-.stat-card-personal {
-  background: var(--color-bg-personal);
-  border: 1px solid var(--color-border-personal);
-}
-
-.stat-card-global {
-  background: var(--color-bg-global);
-  border: 1px solid var(--color-border-global);
-}
-
-.stat-label {
-  font-size: 12px;
-  color: #737B7D;
-  font-weight: 700;
-}
-
-.stat-value {
-  font-weight: 900;
-  font-size: 24px;
-  margin-top: 4px;
-}
-
-/* 오늘 성장 로그 */
-.daily-log {
-  margin-top: 24px;
-  color: var(--color-sub);
-  font-size: 14px;
-}
-
-.highlight-brand {
-  color: var(--color-brand);
-  font-weight: 900;
 }
 
 /* 숲 시각화 컨테이너 */
@@ -98,30 +56,230 @@
   display: grid;
   gap: 16px;
 }
-
-/* 정보 텍스트 */
-.info-text {
-  margin-top: 24px;
-  color: var(--color-sub);
+.forest-card {
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  box-shadow: var(--shadow-soft);
+  position: relative;
 }
-.info-text strong {
-  color: var(--color-text);
+.forest-personal {
+  background: var(--color-bg-personal);
+  border: 1px solid var(--color-border-personal);
 }
-.sub-info {
+.forest-global {
+  background: var(--color-bg-global);
+  border: 1px solid var(--color-border-global);
+  color: #f4fff5;
+  /* 배경 텍스처 느낌 */
+  background-image:
+    radial-gradient(transparent 60%, rgba(255,255,255,0.04) 61%),
+    linear-gradient(0deg, rgba(255,255,255,0.03), rgba(255,255,255,0.03));
+  background-size: 16px 16px, auto;
+}
+.forest-header {
+  display: flex; align-items: center; justify-content: space-between;
+}
+.forest-title {
+  margin: 0; font-weight: 900;
+}
+.forest-title.personal { color: #184b2c; }
+.forest-title.global {
+  color: #ffffff;
+  text-shadow: 0 2px 8px rgba(0,0,0,.35);
+}
+.forest-chip {
   font-size: 12px;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-weight: 700;
+}
+.forest-chip.personal {
+  border: 1px solid #dfeee3;
+  background: #fff;
+  color: #1f6b38;
+}
+.forest-chip.global {
+  border: 1px solid rgba(255,255,255,.18);
+  background: rgba(255,255,255,.12);
+  color: #fff;
+}
+.forest-stats { display: grid; gap: 10px; }
+
+/* 메트릭 타일 */
+.forest-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0,1fr));
+  gap: 10px;
+}
+.metric {
+  text-align: center;
+  padding: 12px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #EEF3EE;
+  color: #184b2c;
+}
+.metric-on-dark {
+  background: rgba(255,255,255,.08);
+  border: 1px solid rgba(255,255,255,.18);
+  color: #ffffff;
+  text-shadow: 0 1px 3px rgba(0,0,0,.25);
+}
+.metric-label {
+  font-size: 12px;
+  color: #3e7a55;
+  font-weight: 700;
+}
+.metric-on-dark .metric-label { color: #e3f1e6; }
+.metric-value {
+  font-weight: 900;
+  font-size: 22px;
   margin-top: 4px;
 }
 
-/* CTA 버튼 */
-.cta-buttons {
-  display: grid;
-  gap: 12px;
-  margin-top: 24px;
+/* 진행바 */
+.progress { display: grid; gap: 6px; }
+.progress-label {
+  display: flex; justify-content: space-between; font-size: 12px; color: var(--color-sub);
+}
+.progress-on-dark .progress-label {
+  color: #e3f1e6; text-shadow: 0 1px 3px rgba(0,0,0,.25);
+}
+.progress-track {
+  height: 10px; width: 100%;
+  background: #E8F5E9;
+  border-radius: 999px; overflow: hidden;
+}
+.progress-on-dark .progress-track { background: rgba(255,255,255,.2); }
+.progress-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--color-brand), var(--color-brand-strong));
+  border-radius: 999px;
+  transition: width .4s ease;
 }
 
-.bin-info {
-  margin-top: 16px;
-  font-size: 12px;
-  color: #737B7D;
-  text-align: center;
+/* 탭 (Day/Week/Month) */
+.tabs {
+  display: inline-flex; gap: 6px; background: rgba(255,255,255,.10);
+  border: 1px solid rgba(255,255,255,.18); border-radius: 999px; padding: 4px;
+}
+.tab-btn {
+  padding: 6px 10px; border-radius: 999px; font-size: 12px; font-weight: 800; color:#e9f5eb;
+}
+.tab-btn.active {
+  background: #1b3b2a; color: #fff; border: 1px solid rgba(255,255,255,.25);
+}
+
+/* ============= ForestField ============= */
+.field-wrap { width: 100%; }
+.field-grass {
+  position: relative;
+  width: 100%;
+  min-height: 160px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #2f804a 0%, #256a3c 100%);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.15),
+              inset 0 2px 14px rgba(0,0,0,.25);
+  overflow: hidden;
+}
+.field-wrap.dark .field-grass {
+  background: linear-gradient(180deg, #21583a 0%, #123a27 100%);
+}
+.field-grass::before {
+  /* 은은한 격자 */
+  content: "";
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(to right, rgba(0,0,0,.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0,0,0,.08) 1px, transparent 1px);
+  background-size: 20px 20px;
+  pointer-events: none;
+}
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(18px, 1fr));
+  gap: 6px;
+  padding: 14px;
+  color: #114d2a;
+  text-shadow: 0 1px 0 rgba(255,255,255,.35);
+}
+.field-wrap.dark .field-grid {
+  color: #0d3b22;
+  text-shadow: 0 1px 0 rgba(255,255,255,.2);
+}
+.tree { filter: drop-shadow(0 1px 0 rgba(255,255,255,.25)) drop-shadow(0 2px 4px rgba(0,0,0,.25)); }
+.field-overflow {
+  position: absolute; right: 10px; bottom: 8px;
+  background: rgba(255,255,255,.85);
+  color: #1b5e20; font-weight: 900; font-size: 12px;
+  padding: 2px 8px; border-radius: 999px;
+  border: 1px solid rgba(0,0,0,.08);
+}
+
+/* 개인 핵심 숫자 (간결) */
+.stats-and-growth-grid {
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px; margin-top: 16px;
+}
+.stat-card {
+  border-radius: 12px; padding: 16px;
+  background: var(--color-bg-personal);
+  border: 1px solid var(--color-border-personal);
+}
+.stat-label { font-size: 12px; color: #737B7D; font-weight: 700; }
+.stat-value { font-weight: 900; font-size: 24px; margin-top: 4px; }
+
+/* 오늘 로그 */
+.daily-log { margin-top: 16px; color: var(--color-sub); font-size: 14px; }
+.highlight-brand { color: var(--color-brand); font-weight: 900; }
+
+/* 리워드 */
+.reward-list { margin-top: 24px; }
+.list-head { display: flex; justify-content: space-between; align-items: baseline; }
+.list-head h3 { margin: 0; font-size: 16px; }
+.my-points { font-size: 12px; color: var(--color-sub); }
+.partner-scroller { display: grid; grid-template-columns: 1fr; gap: 12px; margin-top: 12px; }
+.partner-card { border: 1px solid #EEF2F7; background: #F7FAFF; padding: 14px; border-radius: var(--radius-sm); }
+.partner-title { font-weight: 800; margin-bottom: 8px; }
+.reward-badges { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.badge .badge-btn {
+  border: 1px solid #DDE7F5; background: #fff; border-radius: 999px; padding: 8px 12px;
+  font-size: 12px; font-weight: 800; cursor: pointer;
+  transition: transform .08s ease, box-shadow .2s ease, border-color .2s ease;
+}
+.badge.can .badge-btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-soft); border-color: var(--color-brand); }
+.badge.cannot .badge-btn { opacity: .5; cursor: not-allowed; }
+
+/* 쿠폰함 */
+.coupon-box { margin-top: 16px; }
+.sub-hint { font-size: 12px; color: var(--color-sub); }
+.coupon-list { display: grid; gap: 10px; margin-top: 12px; }
+.coupon-card {
+  border: 1px solid #EEE; border-left: 6px solid var(--color-brand);
+  border-radius: var(--radius-sm); background: #fff; padding: 12px;
+  display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: center;
+}
+.coupon-main .coupon-title { font-weight: 900; }
+.coupon-main .coupon-sub { font-size: 12px; color: var(--color-sub); margin-top: 4px; }
+.coupon-side { display: grid; gap: 6px; justify-items: end; }
+.countdown { font-weight: 900; }
+.chip {
+  background: #EFF7EF; color: #2e7d32;
+  border: 1px solid #DDEDDD; border-radius: 999px; padding: 4px 8px; font-size: 12px;
+}
+.coupon-actions { display: flex; gap: 6px; }
+.status-expired { opacity: .7; border-left-color: #BDBDBD; }
+.status-redeemed { border-left-color: #42A5F5; }
+
+/* CTA */
+.cta-buttons { display: grid; gap: 12px; margin-top: 24px; }
+.bin-info { margin-top: 16px; font-size: 12px; color: #737B7D; text-align: center; }
+
+/* 반응형 */
+@media (min-width: 720px) {
+  .forest-visual-container { grid-template-columns: 1fr 1fr; }
+  .partner-scroller { grid-template-columns: 1fr 1fr; }
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import Header from "../components/Header";
 import Button from "../components/Button";
-import TreeGarden from "../components/TreeGarden";
-import BadgeStrip from "../components/BadgeStrip";
-import "./Dashboard.css"; // CSS 파일 import
+import "./Dashboard.css";
 
-// ---------------- helpers ----------------
+/* ---------------- helpers ---------------- */
 function getUser() {
   const raw = localStorage.getItem("demo_user");
   return raw ? JSON.parse(raw) : null;
@@ -18,6 +16,12 @@ function getGlobal() {
 }
 function setGlobal(g) { localStorage.setItem("global_stats", JSON.stringify(g)); }
 
+function getGlobalDaily() {
+  const raw = localStorage.getItem("global_uses_by_date");
+  return raw ? JSON.parse(raw) : {};
+}
+function setGlobalDaily(map) { localStorage.setItem("global_uses_by_date", JSON.stringify(map)); }
+
 function nowStr() {
   const d = new Date();
   const pad = (n) => n.toString().padStart(2,"0");
@@ -29,16 +33,79 @@ const todayKey = () => {
   return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
 };
 const dailyKeyFor = (user) => `uses_by_date_${user?.name || "guest"}`;
+const redemptionsKeyFor = (user) => `redemptions_${user?.name || "guest"}`;
 
-// ---------------- component ----------------
+/* ---------------- domain: 카페 & 리워드 ---------------- */
+const CAFES = [
+  { id: "espresso-coffee", name: "에스프레소 커피", partner: true },
+  { id: "bruda-coffee", name: "브루다 커피", partner: true },
+  { id: "at-express", name: "AT. EXPRESS", partner: true },
+  { id: "the-bake", name: "더베이크", partner: false },
+  { id: "twosome", name: "투썸 플레이스", partner: true },
+  { id: "the-cafe-n-sookdae", name: "더카페엔 숙대정문점", partner: true },
+  { id: "baekdabang", name: "빽다방", partner: true },
+  { id: "compose-coffee", name: "컴포즈커피", partner: true },
+  { id: "starbucks", name: "스타벅스", partner: true },
+  { id: "bonsol-coffee", name: "본솔커피", partner: true },
+];
+
+const REWARDS = [
+  { id:"bronze", tier:"Bronze", cost:40,  title:"10% OFF 쿠폰", type:"coupon" },
+  { id:"silver", tier:"Silver", cost:80,  title:"사이즈업 쿠폰", type:"coupon" },
+  { id:"gold",   tier:"Gold",   cost:120, title:"₩1,000 할인", type:"coupon" },
+];
+
+/* ===== 조정 가능한 상수 ===== */
+const PERSONAL_PER_TREE = 10; // 개인: 10회 = 1그루
+const COMMUNITY_PER_TREE = 30; // 커뮤니티: 30회 = 1그루
+const REWARD_EXPIRE_HOURS = 48;
+
+function clampPct(n) { return Math.max(0, Math.min(100, Math.round(n))); }
+
+/* ================= ForestField =================
+   넓은 잔디 배경에 작은 나무(🌳)를 “그루 수”만큼 렌더링합니다.
+   - trees: 그루 수(=이모지 개수)
+   - cap: 렌더 상한 (초과분은 +N으로 표시)
+   - size: 이모지 크기(px)
+*/
+function ForestField({ trees = 0, cap = 300, size = 18, label, variant = "light" }) {
+  const count = Math.min(trees, cap);
+  const overflow = Math.max(0, trees - cap);
+
+  return (
+    <div className={`field-wrap ${variant}`} aria-label={label || "forest"}>
+      <div className="field-grass">
+        <div className="field-grid" style={{ fontSize: `${size}px` }}>
+          {Array.from({ length: count }).map((_, i) => (
+            <span className="tree" key={i} role="img" aria-label="tree">🌳</span>
+          ))}
+        </div>
+        {overflow > 0 && (
+          <div className="field-overflow">+{overflow}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------------- main component ---------------- */
 export default function Dashboard({ bin }) {
   const [user, setUserState] = useState(getUser());
   const [global, setGlobalState] = useState(getGlobal());
+  const [globalDaily, setGlobalDailyState] = useState(getGlobalDaily());
 
-  // 일일 사용 기록
   const [todayUses, setTodayUses] = useState(0);
+  const [range, setRange] = useState("day"); // day/week/month
 
-  // 초기 일일 카운트 로드
+  // URL cafe param
+  const [cafeParam, setCafeParam] = useState(null);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const cafe = params.get("cafe");
+    if (cafe) setCafeParam(cafe);
+  }, []);
+
+  // daily counts
   useEffect(() => {
     if (!user) return;
     const mapRaw = localStorage.getItem(dailyKeyFor(user));
@@ -47,66 +114,124 @@ export default function Dashboard({ bin }) {
   }, [user]);
 
   useEffect(() => {
-    if (!user) {
-      // 비로그인 상태라면 웰컴(또는 로그인 페이지)로 유도 가능
+    const gd = getGlobalDaily();
+    setGlobalDailyState(gd);
+  }, []);
+
+  // redemptions
+  const [redeems, setRedeems] = useState(() => {
+    const raw = localStorage.getItem(redemptionsKeyFor(user));
+    return raw ? JSON.parse(raw) : [];
+  });
+  useEffect(() => {
+    localStorage.setItem(redemptionsKeyFor(user), JSON.stringify(redeems));
+  }, [redeems, user]);
+  useEffect(() => {
+    const t = setInterval(() => {
+      setRedeems((prev) => prev.map(r => (r.status === "issued" && Date.now() > r.expireAt) ? { ...r, status: "expired" } : r));
+    }, 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  /* --------- 핵심 수치 계산 --------- */
+  // “그루 수” 계산
+  const treesPersonal = useMemo(
+    () => Math.floor((user?.uses || 0) / PERSONAL_PER_TREE),
+    [user]
+  );
+  const treesCommunity = useMemo(
+    () => Math.floor(global.totalUses / COMMUNITY_PER_TREE),
+    [global.totalUses]
+  );
+
+  // 다음 그루까지 진행도
+  const personalMod = (user?.uses || 0) % PERSONAL_PER_TREE;
+  const personalPct = clampPct((personalMod / PERSONAL_PER_TREE) * 100);
+  const communityMod = global.totalUses % COMMUNITY_PER_TREE;
+  const communityPct = clampPct((communityMod / COMMUNITY_PER_TREE) * 100);
+
+  // 기간 합계 (커뮤니티)
+  const communityRangeSum = useMemo(() => {
+    const today = new Date(todayKey());
+    const days = range === "day" ? 1 : range === "week" ? 7 : 30;
+    let sum = 0;
+    for (let i = 0; i < days; i++) {
+      const d = new Date(today);
+      d.setDate(today.getDate() - i);
+      const key = d.toISOString().slice(0,10);
+      sum += globalDaily[key] || 0;
     }
-  }, [user]);
+    return sum;
+  }, [globalDaily, range]);
 
-  const perTree = 30; // 30회당 1그루로 수정
-  const treesCommunity = useMemo(() => Math.floor(global.totalUses / perTree), [global.totalUses]);
-  const treesPersonal  = useMemo(() => Math.floor((user?.uses || 0) / perTree), [user]);
-
-  // 다음 나무까지 개인 진행률
-  const personalProgress = (user?.uses || 0) % perTree;
-  const personalPct = Math.min(100, Math.round((personalProgress / perTree) * 100));
-
-  const useOnce = () => {
+  /* -------- 쓰레기통 사용 -------- */
+  const useOnceWithCafe = (cafeId) => {
     if (!user) { window.location.href = "/signup"; return; }
 
-    const newUser = { ...user, uses: user.uses + 1, points: user.points + 4 };
-    const newGlobal = {
-      totalUses: global.totalUses + 1,
-      totalPoints: global.totalPoints + 4,
-    };
+    // 1) 개인 적립
+    let newUser = { ...user, uses: user.uses + 1, points: user.points + 4 };
 
-    // 저장
+    // 2) 카페 스탬프 (옵션)
+    const stamps = { ...(newUser.stamps || {}) };
+    if (cafeId) stamps[cafeId] = (stamps[cafeId] || 0) + 1;
+    newUser.stamps = stamps;
+
+    // 3) 저장(개인/전체)
     setUser(newUser); setUserState(newUser);
+    const newGlobal = { totalUses: global.totalUses + 1, totalPoints: global.totalPoints + 4 };
     setGlobal(newGlobal); setGlobalState(newGlobal);
 
-    // 오늘 사용 로그 업데이트
+    // 4) 개인/전체 일일 로그
+    const tk = todayKey();
+
     const k = dailyKeyFor(newUser);
     const raw = localStorage.getItem(k);
     const map = raw ? JSON.parse(raw) : {};
-    const tk = todayKey();
     map[tk] = (map[tk] || 0) + 1;
     localStorage.setItem(k, JSON.stringify(map));
     setTodayUses(map[tk]);
 
-    // 최근 트랜잭션
-    const txn = {
-      time: nowStr(),
-      bin: bin || "BIN-001",
-      pointsGained: 4,
-      userName: newUser.name,
-    };
+    const gmap = getGlobalDaily();
+    gmap[tk] = (gmap[tk] || 0) + 1;
+    setGlobalDaily(gmap);
+    setGlobalDailyState(gmap);
+
+    // 5) 트랜잭션
+    const txn = { time: nowStr(), bin: bin || "BIN-001", pointsGained: 4, userName: newUser.name, cafeId: cafeId || null };
     sessionStorage.setItem("last_txn", JSON.stringify(txn));
 
-    // 유효성 페이지로 이동
+    // 6) 유효성 페이지로 이동
     window.location.href = "/validating";
   };
 
-  const resetDemo = () => {
-    if (window.confirm("데모 데이터를 초기화할까요?")) {
-      localStorage.removeItem("demo_user");
-      localStorage.removeItem("global_stats");
-      sessionStorage.removeItem("last_txn");
-      if (user) localStorage.removeItem(dailyKeyFor(user));
-      setUserState(null);
-      setGlobalState({ totalUses: 0, totalPoints: 0 });
-      setTodayUses(0);
-    }
-  };
+  const useOnce = () => useOnceWithCafe(cafeParam || null);
 
+  /* -------- 리워드 -------- */
+  function redeemReward(reward) {
+    if (!user) return;
+    if (user.points < reward.cost) { alert("포인트가 부족해요."); return; }
+    const code = Math.random().toString(36).slice(2, 8).toUpperCase();
+    const entry = {
+      id: `red_${Date.now()}`,
+      userId: user.id || user.name || "me",
+      cafeId: reward.cafeId,
+      cafeName: reward.cafeName,
+      rewardId: reward.id,
+      title: reward.title,
+      code,
+      status: "issued",
+      issuedAt: nowStr(),
+      expireAt: Date.now() + REWARD_EXPIRE_HOURS * 60 * 60 * 1000,
+    };
+    const newUser = { ...user, points: user.points - reward.cost };
+    setUser(newUser); setUserState(newUser);
+    setRedeems((prev) => [entry, ...prev]);
+    alert(`교환 완료!\n코드: ${code}\n${REWARD_EXPIRE_HOURS}시간 내 사용하세요.`);
+  }
+  const markRedeemed = (id) => setRedeems(prev => prev.map(r => r.id === id ? { ...r, status: "redeemed" } : r));
+  const deleteRedeem = (id) => setRedeems(prev => prev.filter(r => r.id !== id));
+
+  /* ---------------- render ---------------- */
   return (
     <div>
       <Header title="대시보드" />
@@ -114,76 +239,238 @@ export default function Dashboard({ bin }) {
         <section className="dashboard-section">
           <div className="section-title-wrapper">
             <h2 className="section-title">
-              {user ? `${user.name}님 반가워요!` : "로그인이 필요합니다"}
+              {user
+                ? `${user.name}님, 오늘도 한 그루 심어볼까요? 🌱`
+                : "로그인이 필요합니다"}
             </h2>
             <p className="section-subtitle">
-              {user ? (
-                <>쓰레기통 사용 시마다 포인트가 +4 적립됩니다.</>
-              ) : (
-                <>회원가입 또는 로그인 후 사용 기록/포인트 확인이 가능합니다.</>
-              )}
+              {user ? <>쓰레기통을 사용할 때마다 +4p, 우리의 숲이 더 푸르게 자라요.</>
+                   : <>회원가입 또는 로그인 후 이용 기록/포인트를 확인할 수 있어요.</>}
             </p>
           </div>
-          
-          {/* 숫자 카드 */}
-          <div className="stats-grid">
-            <div className="stat-card stat-card-personal">
+
+          {/* 숲 시각화 — 개인(라이트) */}
+          <div className="forest-visual-container">
+            <div className="forest-card forest-personal">
+              <div className="forest-header">
+                <h3 className="forest-title personal">나의 숲</h3>
+                <span className="forest-chip personal">다음 나무까지 {personalPct}%</span>
+              </div>
+
+              {/* 이모지 개수 = 그루 수 */}
+              <ForestField
+                trees={treesPersonal}
+                label="나의 숲"
+                variant="light"
+              />
+
+              <div className="forest-stats">
+                <div className="forest-metrics">
+                  <div className="metric">
+                    <div className="metric-label">내가 키운 나무</div>
+                    <div className="metric-value">{treesPersonal}그루</div>
+                  </div>
+                  <div className="metric">
+                    <div className="metric-label">오늘 내가 재활용한 컵</div>
+                    <div className="metric-value">{todayUses}회</div>
+                  </div>
+                </div>
+                <div className="progress">
+                  <div className="progress-label">
+                    <span>다음 나무까지</span>
+                    <span>{(user?.uses || 0) % PERSONAL_PER_TREE}/{PERSONAL_PER_TREE}</span>
+                  </div>
+                  <div className="progress-track"><div className="progress-fill" style={{ width: `${personalPct}%` }} /></div>
+                </div>
+              </div>
+            </div>
+
+            {/* 숲 시각화 — 커뮤니티(다크) */}
+            <div className="forest-card forest-global">
+              <div className="forest-header">
+                <h3 className="forest-title global">우리의 숲</h3>
+                <div className="tabs" role="tablist" aria-label="기간 선택">
+                  {["day","week","month"].map(k => (
+                    <button key={k} className={`tab-btn ${range===k?"active":""}`} onClick={()=>setRange(k)}>
+                      {k==="day"?"Day":k==="week"?"Week":"Month"}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 이모지 개수 = 그루 수 */}
+              <ForestField
+                trees={treesCommunity}
+                label="우리 모두의 숲"
+                variant="dark"
+              />
+
+              <div className="forest-stats">
+                <div className="forest-metrics">
+                  <div className="metric metric-on-dark">
+                    <div className="metric-label">함께 키운 나무</div>
+                    <div className="metric-value">{treesCommunity}그루</div>
+                  </div>
+                  <div className="metric metric-on-dark">
+                    <div className="metric-label">
+                      {range==="day"?"오늘 재활용된 컵":range==="week"?"최근 7일": "최근 30일"}
+                    </div>
+                    <div className="metric-value">{communityRangeSum}</div>
+                  </div>
+                </div>
+
+                <div className="progress progress-on-dark">
+                  <div className="progress-label">
+                    <span>다음 나무까지</span>
+                    <span>{global.totalUses % COMMUNITY_PER_TREE}/{COMMUNITY_PER_TREE}</span>
+                  </div>
+                  <div className="progress-track"><div className="progress-fill" style={{ width: `${communityPct}%` }} /></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 개인 핵심 숫자 (간결) */}
+          <div className="stats-and-growth-grid">
+            <div className="stat-card">
               <div className="stat-label">나의 사용 횟수</div>
               <div className="stat-value">{user?.uses ?? 0}</div>
             </div>
-            <div className="stat-card stat-card-personal">
+            <div className="stat-card">
               <div className="stat-label">나의 포인트</div>
               <div className="stat-value">{user?.points ?? 0}</div>
             </div>
-            <div className="stat-card stat-card-global">
-              <div className="stat-label">전체 사용 횟수</div>
-              <div className="stat-value">{global.totalUses}</div>
-            </div>
-            <div className="stat-card stat-card-global">
-              <div className="stat-label">전체 포인트</div>
-              <div className="stat-value">{global.totalPoints}</div>
-            </div>
           </div>
 
-          {/* 오늘 성장 로그 */}
+          {/* 오늘 개인 로그 */}
           <div className="daily-log">
-            {user ? (
-              <>오늘 <b className="highlight-brand">{todayUses}</b>회 이용으로 개인 나무가 <b className="highlight-brand">{personalPct}%</b>까지 성장했어요.</>
-            ) : (
-              <>로그인하면 오늘 성장 로그가 표시됩니다.</>
-            )}
+            {user
+              ? <>오늘 <b className="highlight-brand">{todayUses}</b>회 사용으로 개인 숲이 <b className="highlight-brand">{personalPct}%</b> 성장했어요. 한 그루, 또 한 그루 함께 심어요!</>
+              : <>로그인하여 숲을 함께 키워보아요.</>}
           </div>
 
-          {/* 숲 시각화 */}
-          <div className="forest-visual-container">
-            <TreeGarden uses={user?.uses ?? 0} perTree={perTree} label="나의 숲" />
-            <BadgeStrip trees={treesPersonal} />
-            <TreeGarden uses={global.totalUses} perTree={perTree} label="우리 모두의 숲" maxColumns={8} />
-          </div>
+          {/* 제휴 리워드 */}
+          <RewardList user={user} onRedeem={redeemReward} />
 
-          {/* 안내 문구 */}
-          <div className="info-text">
-            <strong>
-              {user?.name || "여러분"}님과 사이트 사용자들이{" "}<br></br>
-              <span className="highlight-brand">{treesCommunity}</span>그루의 나무를 살렸습니다.
-            </strong>
-            {/* 100회당 1그루에서 30회당 1그루로 수정 */}
-            <div className="sub-info">(개인 기준: {treesPersonal} 그루 / 30회당 1그루 환산)</div>
-          </div>
+          {/* 내 쿠폰함 */}
+          <CouponBox items={redeems} onUse={markRedeemed} onDelete={deleteRedeem} />
 
           {/* CTA */}
           <div className="cta-buttons">
-            <Button onClick={useOnce}>{user ? "쓰레기통 사용하기 (+1)" : "로그인/가입 후 이용"}</Button>
-            <Button variant="outline" onClick={resetDemo}>데모 데이터 초기화</Button>
+            <Button onClick={useOnce}>
+              {user ? (cafeParam ? `쓰레기통 사용하기 (+1) · ${CAFES.find(c => c.id === cafeParam)?.name || cafeParam}` : "쓰레기통 사용하기 (+1)") : "로그인/가입 후 이용"}
+            </Button>
+            <Button variant="outline" onClick={()=>{
+              if (window.confirm("데모 데이터를 초기화할까요?")) {
+                localStorage.removeItem("demo_user");
+                localStorage.removeItem("global_stats");
+                localStorage.removeItem("global_uses_by_date");
+                sessionStorage.removeItem("last_txn");
+                if (user) {
+                  localStorage.removeItem(dailyKeyFor(user));
+                }
+                localStorage.removeItem(redemptionsKeyFor(user));
+                setUserState(null);
+                setGlobalState({ totalUses: 0, totalPoints: 0 });
+                setGlobalDailyState({});
+                setRedeems([]);
+                setTodayUses(0);
+                alert("초기화 완료");
+              }
+            }}>데모 데이터 초기화</Button>
           </div>
 
-          {bin && (
+          {(bin || cafeParam) && (
             <div className="bin-info">
-              현재 QR로 전달된 쓰레기통 ID: <strong className="highlight-brand">{bin}</strong>
+              {bin && <>현재 QR 쓰레기통 ID: <strong className="highlight-brand">{bin}</strong></>}
+              {cafeParam && <><br/>제휴 카페: <strong className="highlight-brand">{CAFES.find(c=>c.id===cafeParam)?.name || cafeParam}</strong></>}
             </div>
           )}
         </section>
       </main>
+    </div>
+  );
+}
+
+/* -------- 하위 컴포넌트 -------- */
+function RewardList({ user, onRedeem }) {
+  const userPoints = user?.points ?? 0;
+  const partners = CAFES.filter(c => c.partner);
+  return (
+    <div className="reward-list">
+      <div className="list-head">
+        <h3>제휴 카페 리워드</h3>
+        <span className="my-points">보유 포인트: <b>{userPoints}</b>p</span>
+      </div>
+
+      <div className="partner-scroller">
+        {partners.map(cafe => (
+          <div key={cafe.id} className="partner-card">
+            <div className="partner-title">{cafe.name}</div>
+            <ul className="reward-badges">
+              {REWARDS.map(r => {
+                const can = userPoints >= r.cost;
+                return (
+                  <li key={`${cafe.id}-${r.id}`} className={`badge ${can ? "can" : "cannot"}`}>
+                    <button
+                      className="badge-btn"
+                      onClick={() => can && onRedeem({ ...r, cafeId: cafe.id, cafeName: cafe.name })}
+                      disabled={!can}
+                      title={can ? `${r.title} 교환하기` : "포인트가 부족합니다"}
+                    >
+                      {r.tier} • {r.cost}p
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CouponBox({ items, onUse, onDelete }) {
+  if (!items?.length) return null;
+  return (
+    <div className="coupon-box">
+      <div className="list-head">
+        <h3>내 쿠폰함</h3>
+        <span className="sub-hint">만료까지 최대 {REWARD_EXPIRE_HOURS}시간</span>
+      </div>
+      <div className="coupon-list">
+        {items.map(it => {
+          const remain = it.expireAt - Date.now();
+          const hh = Math.max(0, Math.floor(remain / (1000 * 60 * 60)));
+          const mm = Math.max(0, Math.floor((remain % (1000 * 60 * 60)) / (1000 * 60)));
+          const ss = Math.max(0, Math.floor((remain % (1000 * 60)) / 1000));
+          return (
+            <div key={it.id} className={`coupon-card status-${it.status}`}>
+              <div className="coupon-main">
+                <div className="coupon-title">{it.title}</div>
+                <div className="coupon-sub">{it.cafeName} • 코드 <b>{it.code}</b></div>
+              </div>
+              <div className="coupon-side">
+                {it.status === "issued" && remain > 0 && (
+                  <div className="countdown" aria-label="만료까지 남은 시간">
+                    {hh}h {mm}m {ss}s
+                  </div>
+                )}
+                {it.status !== "issued" && (
+                  <div className="chip">{it.status === "redeemed" ? "사용됨" : "만료"}</div>
+                )}
+                <div className="coupon-actions">
+                  {it.status === "issued" && remain > 0 && (
+                    <Button size="sm" onClick={() => onUse(it.id)}>사용 완료</Button>
+                  )}
+                  <Button size="sm" variant="outline" onClick={() => onDelete(it.id)}>삭제</Button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/pages/SignUp.css
+++ b/src/pages/SignUp.css
@@ -120,3 +120,8 @@
   font-size: 12px;
   margin-top: 4px;
 }
+
+/* 로그인 */
+.signin-prompt { text-align: center; margin-top: 12px; color: #757575; font-size: 14px; }
+.signin-link { color: #4CAF50; font-weight: 700; text-decoration: underline; }
+.signin-link:hover { opacity: 0.8; }

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,9 +1,10 @@
 // src/pages/SignUp.jsx
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import Header from "../components/Header";
 import Button from "../components/Button";
 import InputField from "../components/InputField";
-import "./SignUp.css"; // CSS 파일 import
+import "./SignUp.css";
 
 export default function SignUp() {
   const [name, setName] = useState("");
@@ -13,10 +14,12 @@ export default function SignUp() {
   const [termsAgreed, setTermsAgreed] = useState(false);
 
   // 이메일 유효성 검사 정규식
-  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+  const emailRegex =
+    /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   const isEmailValid = emailRegex.test(email);
   const isPwMatch = pw === pw2;
-  const isFormValid = name && isEmailValid && pw && isPwMatch && termsAgreed;
+  const isFormValid =
+    name.trim() && isEmailValid && pw && isPwMatch && termsAgreed;
 
   const onSubmit = (e) => {
     e.preventDefault();
@@ -24,7 +27,7 @@ export default function SignUp() {
       alert("모든 필드를 올바르게 입력하고 약관에 동의해주세요.");
       return;
     }
-    const user = { name, email, points: 0, uses: 0 };
+    const user = { name: name.trim(), email: email.trim(), points: 0, uses: 0 };
     localStorage.setItem("demo_user", JSON.stringify(user));
     window.location.href = "/validating";
   };
@@ -33,58 +36,90 @@ export default function SignUp() {
     <div className="signup-container">
       <Header title="회원가입" back />
       <main className="signup-main">
-        <p className="signup-greeting">어서오세요! <span className="highlight-text">(프로젝트명)</span> 입니다.</p>
+        <p className="signup-greeting">
+          어서오세요! <span className="highlight-text">Cupcycle</span> 입니다.
+        </p>
 
-        <form className="signup-form" onSubmit={onSubmit}>
-          <InputField 
-            label="이름" 
-            value={name} 
-            onChange={e => setName(e.target.value)} 
-            placeholder="홍길동"
+        <form className="signup-form" onSubmit={onSubmit} noValidate>
+          <InputField
+            label="이름"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="김눈송"
             required
           />
+
           <InputField
-            label="이메일"
+            label="이메일 (아이디)"
             type="email"
             value={email}
-            onChange={e => setEmail(e.target.value)}
+            onChange={(e) => setEmail(e.target.value)}
             placeholder="name@example.com"
             error={email && !isEmailValid ? "유효한 이메일 형식을 입력해주세요." : null}
             required
+            autoComplete="username"
           />
+
           <InputField
             label="비밀번호"
             type="password"
             value={pw}
-            onChange={e => setPw(e.target.value)}
+            onChange={(e) => setPw(e.target.value)}
             placeholder="비밀번호를 입력하세요"
             required
+            autoComplete="new-password"
           />
+
           <InputField
             label="비밀번호 확인"
             type="password"
             value={pw2}
-            onChange={e => setPw2(e.target.value)}
+            onChange={(e) => setPw2(e.target.value)}
             placeholder="비밀번호를 다시 입력하세요"
             error={pw2 && !isPwMatch ? "비밀번호가 일치하지 않습니다." : null}
             required
+            autoComplete="new-password"
           />
 
           <label className="terms-label">
-            <input 
-              type="checkbox" 
+            <input
+              type="checkbox"
               checked={termsAgreed}
-              onChange={e => setTermsAgreed(e.target.checked)}
+              onChange={(e) => setTermsAgreed(e.target.checked)}
               required
             />
             <span>
-              <a href="/terms" className="terms-link" onClick={e => e.preventDefault()}>약관</a> 및{" "}
-              <a href="/privacy" className="terms-link" onClick={e => e.preventDefault()}>개인정보 처리방침</a>에 동의합니다.
+              <a
+                href="/terms"
+                className="terms-link"
+                onClick={(e) => e.preventDefault()}
+              >
+                약관
+              </a>{" "}
+              및{" "}
+              <a
+                href="/privacy"
+                className="terms-link"
+                onClick={(e) => e.preventDefault()}
+              >
+                개인정보 처리방침
+              </a>
+              에 동의합니다.
             </span>
           </label>
 
-          <Button type="submit" disabled={!isFormValid}>가입하기</Button>
+          <Button type="submit" disabled={!isFormValid}>
+            가입하기
+          </Button>
         </form>
+
+        {/* 로그인 유도 섹션 */}
+        <div className="signin-prompt" role="note" aria-live="polite">
+          이미 아이디가 있으신가요?{" "}
+          <Link to="/login" className="signin-link">
+            로그인하기
+          </Link>
+        </div>
       </main>
     </div>
   );

--- a/src/pages/Welcome.jsx
+++ b/src/pages/Welcome.jsx
@@ -20,7 +20,7 @@ export default function Welcome() {
 
       {/* 히어로 섹션 */}
       <section className="hero-section" role="banner">
-        <h1>(프로젝트명)</h1>
+        <h1>CupCycle</h1>
         <p className="hero-subtitle">지속 가능한 선택을 위한 첫걸음</p>
       </section>
 
@@ -32,14 +32,14 @@ export default function Welcome() {
         {/* 우리 모두의 숲 - 요약 티저 (CTA 위에 배치) */}
         <div className="forest-teaser-wrap" aria-label="우리 모두의 숲 요약">
           {/* perTree=100 기준, localStorage의 global_stats.totalUses 사용 */}
-          <TreeTeaser perTree={100} />
+          <TreeTeaser perTree={30} />
         </div>
 
         <div className="cta-container">
           <Button as={Link} to="/signup" variant="primary" block>
             회원가입
           </Button>
-          <Button as={Link} to="/dashboard" variant="outline" block>
+          <Button as={Link} to="/login" variant="outline" block>
             로그인
           </Button>
         </div>


### PR DESCRIPTION
## 변경 사항
- Dashboard.jsx/css
  - 개인=10, 커뮤니티=30 상수화 및 진행도/그루 계산 반영
  - ForestField(넓은 그린 배경 + 🌳 격자) 도입, +N 오버플로 표기
  - ‘나의 숲’(라이트) vs ‘우리 모두의 숲’(다크) 대비/텍스트 컬러 분리
  - Focused Time Distribution 제거, 인사 문구 교체
  - 리워드 만료 48h
- TreeTeaser.jsx/css
  - 커뮤니티 30회/그루 반영, 진행바 `aria-*` 정리
  - storage/visibilitychange/폴링으로 실시간 동기화, 오버플로 `+N`
- SignUp.jsx/css
  - 하단 “이미 아이디가 있으신가요? 로그인하기” 추가
- 정리
  - 사용 안 하는 임포트/변수 제거(ESLint 경고 해소)

## 테스트 방법
1. 새 사용자 가입 → 대시보드 진입
2. “쓰레기통 사용하기”로 uses 증가 확인(개인 10회마다 🌳 1그루, 커뮤니티 30회마다 1그루)
3. 새 탭에서 메인(티저) 열고 대시보드에서 사용 증가 → 티저 실시간 반영 확인
4. SignUp 화면에서 로그인 링크 동작 확인
5. 쿠폰 발급/사용/만료/삭제 플로우 확인(만료 48h)

## 접근성
- 진행바 `role="progressbar"` 및 `aria-valuemin/max/now` 적용
- 다크 카드 대비(텍스트/라벨/프로그레스) 향상

## 리스크/성능
- 티저 격자 렌더 cap(`maxTiles`)로 과도한 DOM 방지
- 상수 기반 정책 변경 용이

## 관련 이슈
Closes #5 

